### PR TITLE
Fix space name is not reflecting on home screen

### DIFF
--- a/app/src/main/java/com/canopas/yourspace/domain/utils/DateFormatter.kt
+++ b/app/src/main/java/com/canopas/yourspace/domain/utils/DateFormatter.kt
@@ -79,7 +79,9 @@ fun Long.isToday(): Boolean {
     )
 }
 
-fun timeAgo(timestamp: Long): String {
+fun timeAgo(timestamp: Long?): String {
+    if (timestamp == null) return ""
+
     val now = System.currentTimeMillis()
     val seconds = (now - timestamp) / 1000
 

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/home/home/HomeScreenViewModel.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/home/home/HomeScreenViewModel.kt
@@ -77,10 +77,13 @@ class HomeScreenViewModel @Inject constructor(
     private fun getAllSpaces() = viewModelScope.launch(appDispatcher.IO) {
         try {
             _state.emit(_state.value.copy(isLoadingSpaces = _state.value.spaces.isEmpty()))
+            Timber.d("XXX home Spaces called")
             spaceRepository.getAllSpaceInfo().collectLatest { spaces ->
+                Timber.d("XXX home Spaces get")
                 if (spaceRepository.currentSpaceId.isEmpty() && spaces.isNotEmpty()) {
                     spaceRepository.currentSpaceId = spaces.firstOrNull()?.space?.id ?: ""
                 }
+                Timber.d("XXX home Spaces: $spaces")
                 val tempSpaces = spaces.toMutableList()
                 val index =
                     tempSpaces.indexOfFirst { it.space.id == spaceRepository.currentSpaceId }

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/home/home/HomeScreenViewModel.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/home/home/HomeScreenViewModel.kt
@@ -77,13 +77,10 @@ class HomeScreenViewModel @Inject constructor(
     private fun getAllSpaces() = viewModelScope.launch(appDispatcher.IO) {
         try {
             _state.emit(_state.value.copy(isLoadingSpaces = _state.value.spaces.isEmpty()))
-            Timber.d("XXX home Spaces called")
             spaceRepository.getAllSpaceInfo().collectLatest { spaces ->
-                Timber.d("XXX home Spaces get")
                 if (spaceRepository.currentSpaceId.isEmpty() && spaces.isNotEmpty()) {
                     spaceRepository.currentSpaceId = spaces.firstOrNull()?.space?.id ?: ""
                 }
-                Timber.d("XXX home Spaces: $spaces")
                 val tempSpaces = spaces.toMutableList()
                 val index =
                     tempSpaces.indexOfFirst { it.space.id == spaceRepository.currentSpaceId }

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/home/map/component/SelectedUserDetail.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/home/map/component/SelectedUserDetail.kt
@@ -135,14 +135,16 @@ private fun MemberProfileView(profileUrl: String?, name: String, session: ApiUse
 private fun MemberInfoView(userName: String, location: ApiLocation?, onTapTimeline: () -> Unit) {
     val context = LocalContext.current
     var address by remember { mutableStateOf("") }
-    val time = timeAgo(location?.created_at ?: 0)
+    val time = timeAgo(location?.created_at ?: System.currentTimeMillis())
 
     LaunchedEffect(location) {
+        if (location == null) return@LaunchedEffect
         withContext(Dispatchers.IO) {
-            val latLng = LatLng(location!!.latitude, location.longitude)
+            val latLng = LatLng(location.latitude, location.longitude)
             address = latLng.getAddress(context) ?: ""
         }
     }
+
     Column(modifier = Modifier.padding(start = 16.dp)) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Text(

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/home/map/component/SelectedUserDetail.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/home/map/component/SelectedUserDetail.kt
@@ -135,10 +135,12 @@ private fun MemberProfileView(profileUrl: String?, name: String, session: ApiUse
 private fun MemberInfoView(userName: String, location: ApiLocation?, onTapTimeline: () -> Unit) {
     val context = LocalContext.current
     var address by remember { mutableStateOf("") }
-    val time = timeAgo(location?.created_at ?: System.currentTimeMillis())
+    val time = timeAgo(location?.created_at)
 
     LaunchedEffect(location) {
-        if (location == null) return@LaunchedEffect
+        if (location == null) {
+            address = ""; return@LaunchedEffect
+        }
         withContext(Dispatchers.IO) {
             val latLng = LatLng(location.latitude, location.longitude)
             address = latLng.getAddress(context) ?: ""
@@ -169,18 +171,20 @@ private fun MemberInfoView(userName: String, location: ApiLocation?, onTapTimeli
             modifier = Modifier.padding(top = 12.dp)
         )
 
-        Row(modifier = Modifier.padding(top = 4.dp)) {
-            Icon(
-                painter = painterResource(id = R.drawable.ic_access_time),
-                contentDescription = "",
-                tint = AppTheme.colorScheme.textDisabled,
-                modifier = Modifier.size(16.dp)
-            )
-            Spacer(modifier = Modifier.width(4.dp))
-            Text(
-                text = time,
-                style = AppTheme.appTypography.caption.copy(color = AppTheme.colorScheme.textDisabled)
-            )
+        if (time.isNotEmpty()) {
+            Row(modifier = Modifier.padding(top = 4.dp)) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_access_time),
+                    contentDescription = "",
+                    tint = AppTheme.colorScheme.textDisabled,
+                    modifier = Modifier.size(16.dp)
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(
+                    text = time,
+                    style = AppTheme.appTypography.caption.copy(color = AppTheme.colorScheme.textDisabled)
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/onboard/components/SpaceInfoOnboard.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/onboard/components/SpaceInfoOnboard.kt
@@ -10,8 +10,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/onboard/components/SpaceInfoOnboard.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/onboard/components/SpaceInfoOnboard.kt
@@ -29,7 +29,6 @@ import com.canopas.yourspace.ui.theme.AppTheme
 @Composable
 fun SpaceInfoOnboard() {
     val viewModel = hiltViewModel<OnboardViewModel>()
-    val state by viewModel.state.collectAsState()
 
     Column(
         Modifier
@@ -61,6 +60,7 @@ fun SpaceInfoOnboard() {
         Spacer(modifier = Modifier.height(16.dp))
 
         PrimaryOutlinedButton(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
             label = stringResource(R.string.common_btn_skip),
             onClick = { viewModel.navigateToHome() }
         )

--- a/data/src/main/java/com/canopas/yourspace/data/service/space/ApiSpaceService.kt
+++ b/data/src/main/java/com/canopas/yourspace/data/service/space/ApiSpaceService.kt
@@ -68,6 +68,8 @@ class ApiSpaceService @Inject constructor(
     suspend fun getSpace(spaceId: String) =
         spaceRef.document(spaceId).get().await().toObject(ApiSpace::class.java)
 
+    fun getSpaceFlow(spaceId: String) = spaceRef.document(spaceId).snapshotFlow(ApiSpace::class.java)
+
     fun getSpaceMemberByUserId(userId: String) =
         db.collectionGroup(FIRESTORE_COLLECTION_SPACE_MEMBERS).whereEqualTo("user_id", userId)
             .snapshotFlow(ApiSpaceMember::class.java)


### PR DESCRIPTION
- space name is not reflecting on home screen.
- Fix bug on  member selection.
- Fix space info onboard screen button size.

[Fix_space_name.webm](https://github.com/canopas/your-space-android/assets/140153665/eb26de8e-60b4-4361-afaf-7d4d64815aff)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new `getSpaceFlow` function in `ApiSpaceService` for fetching space snapshots using flow.

- **Improvements**
  - Updated the `MemberInfoView` function to better handle null `location` values, improving UI stability.
  - Enhanced the `timeAgo` function to handle nullable timestamps, preventing potential crashes.

- **Refactor**
  - Refactored `getUserSpaces` in `SpaceRepository` to return a `Flow` of `ApiSpace`, improving data handling and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->