### PR TITLE
Fix home and join space screen ui

### DIFF
--- a/app/src/main/java/com/canopas/yourspace/ui/component/OtpTextField.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/component/OtpTextField.kt
@@ -93,7 +93,7 @@ private fun OTPDigit(
     pinText: String,
     textStyle: TextStyle,
     focusRequester: FocusRequester,
-    width: Dp,
+    width: Dp
 ) {
     val isFocused = pinText.length == index
     val keyboardController = LocalSoftwareKeyboardController.current

--- a/app/src/main/java/com/canopas/yourspace/ui/component/OtpTextField.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/component/OtpTextField.kt
@@ -4,12 +4,13 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
@@ -27,6 +28,7 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.canopas.yourspace.ui.theme.AppTheme
 
@@ -38,36 +40,47 @@ fun OtpInputField(
     digitCount: Int = 6
 ) {
     val focusRequester = remember { FocusRequester() }
+    BoxWithConstraints(
+        Modifier
+            .widthIn(max = 600.dp)
+            .fillMaxWidth(),
+        contentAlignment = Alignment.Center
+    ) {
+        val width = (maxWidth - 32.dp) / (digitCount + 1)
 
-    BasicTextField(
-        value = pinText,
-        onValueChange = {
-            if (it.length <= digitCount) {
-                onPinTextChange(it)
-            }
-        },
-        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
-        modifier = Modifier.focusRequester(focusRequester),
-        decorationBox = {
-            Row {
-                repeat(digitCount) { index ->
-                    OTPDigit(index, pinText, textStyle, focusRequester)
-                    Spacer(modifier = Modifier.width(8.dp))
-                    if (index == 2) {
-                        HorizontalDivider(
-                            modifier = Modifier
-                                .padding(horizontal = 16.dp)
-                                .width(16.dp)
-                                .align(Alignment.CenterVertically),
-                            thickness = 2.dp,
-                            color = AppTheme.colorScheme.textPrimary
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
+        BasicTextField(
+            value = pinText,
+            onValueChange = {
+                if (it.length <= digitCount) {
+                    onPinTextChange(it)
+                }
+            },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
+            modifier = Modifier.focusRequester(focusRequester),
+            decorationBox = {
+                Row(
+                    Modifier
+                        .fillMaxWidth()
+                        .align(Alignment.Center),
+                    horizontalArrangement = Arrangement.SpaceEvenly
+                ) {
+                    repeat(digitCount) { index ->
+                        OTPDigit(index, pinText, textStyle, focusRequester, width = width)
+
+                        if (index == 2) {
+                            HorizontalDivider(
+                                modifier = Modifier
+                                    .width(16.dp)
+                                    .align(Alignment.CenterVertically),
+                                thickness = 2.dp,
+                                color = AppTheme.colorScheme.textPrimary
+                            )
+                        }
                     }
                 }
             }
-        }
-    )
+        )
+    }
 
     LaunchedEffect(key1 = Unit) {
         focusRequester.requestFocus()
@@ -79,7 +92,8 @@ private fun OTPDigit(
     index: Int,
     pinText: String,
     textStyle: TextStyle,
-    focusRequester: FocusRequester
+    focusRequester: FocusRequester,
+    width: Dp,
 ) {
     val isFocused = pinText.length == index
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -95,7 +109,7 @@ private fun OTPDigit(
         Text(
             text = if (index >= pinText.length) "" else pinText[index].toString().uppercase(),
             modifier = Modifier
-                .width(48.dp)
+                .width(width)
                 .height(64.dp)
                 .background(
                     color = if (isFocused) AppTheme.colorScheme.containerLow else AppTheme.colorScheme.containerNormal,

--- a/app/src/main/java/com/canopas/yourspace/ui/flow/home/map/MapScreen.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/home/map/MapScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -161,55 +162,62 @@ fun MapScreen() {
                     }
                 }
             }
-            val selectedUser = state.selectedUser
-            AnimatedVisibility(
-                visible = state.showUserDetails,
-                enter = slideInVertically { it } + scaleIn() + expandVertically(expandFrom = Alignment.Top),
-                exit = scaleOut() + slideOutVertically(targetOffsetY = { it }) + shrinkVertically(
-                    shrinkTowards = Alignment.Bottom
-                )
-            ) {
-                SelectedUserDetail(
-                    userInfo = selectedUser,
-                    onDismiss = { viewModel.dismissMemberDetail() },
-                    onTapTimeline = { viewModel.showJourneyTimeline() }
-                )
-            }
-
-            if (state.members.isNotEmpty()) {
-                LazyRow(
-                    modifier = Modifier
-                        .padding(start = 16.dp, end = 16.dp, bottom = 16.dp)
-                        .widthIn(max = 600.dp)
-                        .wrapContentSize()
-                        .background(
-                            AppTheme.colorScheme.surface,
-                            shape = RoundedCornerShape(50.dp)
+            LazyColumn(modifier = Modifier.align(Alignment.CenterHorizontally)) {
+                item {
+                    val selectedUser = state.selectedUser
+                    AnimatedVisibility(
+                        visible = state.showUserDetails,
+                        enter = slideInVertically { it } + scaleIn() + expandVertically(expandFrom = Alignment.Top),
+                        exit = scaleOut() + slideOutVertically(targetOffsetY = { it }) + shrinkVertically(
+                            shrinkTowards = Alignment.Bottom
                         )
-                        .padding(horizontal = 24.dp, vertical = 8.dp)
-                        .align(Alignment.CenterHorizontally),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(12.dp)
-                ) {
-                    item {
-                        AddMemberBtn(state.loadingInviteCode) { viewModel.addMember() }
+                    ) {
+                        SelectedUserDetail(
+                            userInfo = selectedUser,
+                            onDismiss = { viewModel.dismissMemberDetail() },
+                            onTapTimeline = { viewModel.showJourneyTimeline() }
+                        )
                     }
-                    items(state.members) {
-                        MapUserItem(it) {
-                            viewModel.showMemberDetail(it)
+                }
+                item {
+                    if (state.members.isNotEmpty()) {
+                        LazyRow(
+                            modifier = Modifier.fillMaxWidth()
+                                .padding(start = 16.dp, end = 16.dp, bottom = 16.dp)
+                                .widthIn(max = 600.dp)
+                                .wrapContentSize()
+                                .background(
+                                    AppTheme.colorScheme.surface,
+                                    shape = RoundedCornerShape(50.dp)
+                                )
+                                .padding(horizontal = 24.dp, vertical = 8.dp)
+                                .align(Alignment.CenterHorizontally),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(12.dp)
+                        ) {
+                            item {
+                                AddMemberBtn(state.loadingInviteCode) { viewModel.addMember() }
+                            }
+                            items(state.members) {
+                                MapUserItem(it) {
+                                    viewModel.showMemberDetail(it)
+                                }
+                            }
                         }
                     }
                 }
-            }
 
-            val context = LocalContext.current
-            AnimatedVisibility(
-                visible = !context.hasAllPermission || !context.isLocationServiceEnabled() || !context.hasNotificationPermission,
-                enter = slideInVertically(tween(100)) { it },
-                exit = slideOutVertically(tween(100)) { it }
-            ) {
-                PermissionFooter() {
-                    viewModel.navigateToPermissionScreen()
+                item {
+                    val context = LocalContext.current
+                    AnimatedVisibility(
+                        visible = !context.hasAllPermission || !context.isLocationServiceEnabled() || !context.hasNotificationPermission,
+                        enter = slideInVertically(tween(100)) { it },
+                        exit = slideOutVertically(tween(100)) { it }
+                    ) {
+                        PermissionFooter() {
+                            viewModel.navigateToPermissionScreen()
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
- Fixed home screen bottom footer member detail is not showing in landscape mode.
- Fixed join space code text field ui breaking in small devices.


[Fix ui.webm](https://github.com/user-attachments/assets/de1d748e-6c62-4987-909d-297e8b9c6edc)


https://github.com/user-attachments/assets/29f27461-a36f-41d5-9252-189d3427e3be


https://github.com/user-attachments/assets/337613fc-0256-46f6-b2a1-0d96c2ff008f



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced OTP input field layout for improved responsiveness and visual appeal.
	- Introduced a dynamic, scrollable layout in the MapScreen for better content management.

- **Bug Fixes**
	- Adjusted spacing and alignment of OTP digits for a more consistent user experience. 

- **Refactor**
	- Restructured UI components in the MapScreen for improved organization and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->