### PR TITLE
Prevent app crash due to empty doc id

### DIFF
--- a/data/src/main/java/com/canopas/yourspace/data/service/location/ApiJourneyService.kt
+++ b/data/src/main/java/com/canopas/yourspace/data/service/location/ApiJourneyService.kt
@@ -20,8 +20,13 @@ class ApiJourneyService @Inject constructor(
     private val converters: LocationConverters
 ) {
     private val userRef = db.collection(Config.FIRESTORE_COLLECTION_USERS)
+
+    // App crashes sometimes because of the empty userId string passed to document().
+    // java.lang.IllegalArgumentException: Invalid document reference.
+    // Document references must have an even number of segments, but users has 1
+    // https://stackoverflow.com/a/51195713/22508023 [Explanation can be found in comments]
     private fun journeyRef(userId: String) =
-        userRef.document(userId)
+        userRef.document(userId.takeIf { it.isNotBlank() } ?: "null")
             .collection(Config.FIRESTORE_COLLECTION_USER_JOURNEYS)
 
     suspend fun saveCurrentJourney(

--- a/data/src/main/java/com/canopas/yourspace/data/service/messages/ApiMessagesService.kt
+++ b/data/src/main/java/com/canopas/yourspace/data/service/messages/ApiMessagesService.kt
@@ -29,7 +29,11 @@ class ApiMessagesService @Inject constructor(
     private val threadRef = db.collection(FIRESTORE_COLLECTION_SPACE_THREADS)
 
     private fun threadMessagesRef(threadId: String) =
-        threadRef.document(threadId).collection(Config.FIRESTORE_COLLECTION_THREAD_MESSAGES)
+        threadRef.document(
+            threadId.takeIf {
+                it.isNotBlank()
+            } ?: "null"
+        ).collection(Config.FIRESTORE_COLLECTION_THREAD_MESSAGES)
 
     suspend fun createThread(spaceId: String, adminId: String): String {
         val docRef = threadRef.document()

--- a/data/src/main/java/com/canopas/yourspace/data/service/place/ApiPlaceService.kt
+++ b/data/src/main/java/com/canopas/yourspace/data/service/place/ApiPlaceService.kt
@@ -25,11 +25,11 @@ class ApiPlaceService @Inject constructor(
     private val spaceRef = db.collection(Config.FIRESTORE_COLLECTION_SPACES)
 
     private fun spacePlacesRef(spaceId: String) =
-        spaceRef.document(spaceId).collection(Config.FIRESTORE_COLLECTION_SPACE_PLACES)
+        spaceRef.document(spaceId.takeIf { it.isNotBlank() } ?: "null").collection(Config.FIRESTORE_COLLECTION_SPACE_PLACES)
 
     private fun spacePlacesSettingsRef(spaceId: String, placeId: String) =
-        spaceRef.document(spaceId).collection(Config.FIRESTORE_COLLECTION_SPACE_PLACES)
-            .document(placeId).collection(
+        spaceRef.document(spaceId.takeIf { it.isNotBlank() } ?: "null").collection(Config.FIRESTORE_COLLECTION_SPACE_PLACES)
+            .document(placeId.takeIf { it.isNotBlank() } ?: "null").collection(
                 Config.FIRESTORE_COLLECTION_SPACE_PLACES_MEMBER_SETTINGS
             )
 

--- a/data/src/main/java/com/canopas/yourspace/data/service/space/ApiSpaceService.kt
+++ b/data/src/main/java/com/canopas/yourspace/data/service/space/ApiSpaceService.kt
@@ -39,7 +39,6 @@ class ApiSpaceService @Inject constructor(
     suspend fun joinSpace(spaceId: String, role: Int = SPACE_MEMBER_ROLE_MEMBER) {
         val userId = authService.currentUser?.id ?: ""
         spaceMemberRef(spaceId)
-        spaceMemberRef(spaceId)
             .document(userId).also {
                 val member = ApiSpaceMember(
                     space_id = spaceId,
@@ -55,14 +54,12 @@ class ApiSpaceService @Inject constructor(
 
     suspend fun enableLocation(spaceId: String, userId: String, enable: Boolean) {
         spaceMemberRef(spaceId)
-        spaceMemberRef(spaceId)
             .whereEqualTo("user_id", userId).get()
             .await().documents.firstOrNull()
             ?.reference?.update("location_enabled", enable)?.await()
     }
 
     suspend fun isMember(spaceId: String, userId: String): Boolean {
-        spaceMemberRef(spaceId)
         val query = spaceMemberRef(spaceId)
             .whereEqualTo("user_id", userId)
         val result = query.get().await()
@@ -82,7 +79,6 @@ class ApiSpaceService @Inject constructor(
         spaceMemberRef(spaceId).snapshotFlow(ApiSpaceMember::class.java)
 
     private suspend fun deleteMembers(spaceId: String) {
-        spaceMemberRef(spaceId)
         spaceMemberRef(spaceId).get().await().documents.forEach { doc ->
             doc.reference.delete().await()
         }
@@ -95,7 +91,6 @@ class ApiSpaceService @Inject constructor(
 
     suspend fun removeUserFromSpace(spaceId: String, userId: String) {
         placeService.removedUserFromExistingPlaces(spaceId, userId)
-        spaceMemberRef(spaceId)
         spaceMemberRef(spaceId)
             .whereEqualTo("user_id", userId).get().await().documents.forEach {
                 it.reference.delete().await()

--- a/data/src/main/java/com/canopas/yourspace/data/service/user/ApiUserService.kt
+++ b/data/src/main/java/com/canopas/yourspace/data/service/user/ApiUserService.kt
@@ -32,7 +32,7 @@ class ApiUserService @Inject constructor(
 ) {
     private val userRef = db.collection(FIRESTORE_COLLECTION_USERS)
     private fun sessionRef(userId: String) =
-        userRef.document(userId).collection(Config.FIRESTORE_COLLECTION_USER_SESSIONS)
+        userRef.document(userId.takeIf { it.isNotBlank() } ?: "null").collection(Config.FIRESTORE_COLLECTION_USER_SESSIONS)
 
     suspend fun getUser(userId: String): ApiUser? {
         return try {


### PR DESCRIPTION
# Changelog

[Quick description and/or mentions to other PRs]

## Bug Fixes

```
java.lang.IllegalArgumentException: Invalid document reference.
 Document references must have an even number of segments, but users has 1

```

- Fix app crash caused due to empty path provided in document reference




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced error handling for user IDs, thread IDs, space IDs, and place IDs to prevent application crashes due to empty strings.
	- Improved robustness in Firestore document reference creation across multiple services.

- **Bug Fixes**
	- Addressed potential null pointer exceptions by ensuring valid references are returned for various identifiers.

- **Refactor**
	- Streamlined code by removing unnecessary null checks and simplifying logic for document reference retrieval across multiple services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->