### PR TITLE
fix button width on pick-name-onboard screen.

### DIFF
--- a/app/src/main/java/com/canopas/yourspace/ui/flow/onboard/components/PickNameOnboard.kt
+++ b/app/src/main/java/com/canopas/yourspace/ui/flow/onboard/components/PickNameOnboard.kt
@@ -15,14 +15,13 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalFocusManager
@@ -39,7 +38,6 @@ import com.canopas.yourspace.ui.flow.onboard.OnboardViewModel
 import com.canopas.yourspace.ui.theme.AppTheme
 import com.canopas.yourspace.ui.theme.CatchMeTheme
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun PickNameOnboard() {
     val viewModel = hiltViewModel<OnboardViewModel>()
@@ -75,7 +73,7 @@ fun PickNameOnboard() {
         Spacer(modifier = Modifier.weight(1f))
         PrimaryButton(
             label = stringResource(R.string.common_btn_next),
-            modifier = Modifier.align(Alignment.CenterHorizontally),
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
             onClick = {
                 keyboard?.hide()
                 viewModel.navigateToSpaceInfo()
@@ -135,7 +133,7 @@ private fun PickNameTextField(title: String, value: String, onValueChanged: (Str
             cursorBrush = SolidColor(AppTheme.colorScheme.primary)
         )
 
-        Divider(
+        HorizontalDivider(
             Modifier.align(Alignment.BottomCenter),
             thickness = 1.dp,
             color = outlineColor


### PR DESCRIPTION
# Changelog

**pickNameOnboardScreen**
Fix button width :- The button's width is now set to max width.
Fix deprecated properties :- Removed deprecated properties to comply with the latest API standards.

## Bug Fixes

- Fixed issue where the button's width was not expanding to its maximum size.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved layout of the onboarding screen by enhancing button alignment and width.
	- Updated visual elements for better consistency with the introduction of `HorizontalDivider`. 

- **Bug Fixes**
	- Resolved alignment issues with the `PrimaryButton` for a more user-friendly interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->